### PR TITLE
#161531945 Implement modify product category feature

### DIFF
--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -25,6 +25,28 @@ class CategoryController {
     }
     res.status(201).json({ status: true, result });
   }
+
+  /**
+   *
+   * @description Updates a product category in the store
+   * @static
+   * @param {object} req Request Object
+   * @param {object} res Response Object
+   * @param {object} next calls the next middleware in the request-response cycle
+   * @returns {object} Updated category object
+   * @memberof CategoryController
+   */
+  static async updateCategory(req, res, next) {
+    const { id } = req.params;
+    const { name } = req.body;
+
+    const result = await CategoryHelper.updateCategory({ id, name });
+    if (result instanceof Error) {
+      next(result);
+      return;
+    }
+    res.status(200).json({ status: true, result });
+  }
 }
 
 export default CategoryController;

--- a/server/helpers/categoryHelper.js
+++ b/server/helpers/categoryHelper.js
@@ -15,7 +15,7 @@ class CategoryHelper {
    * @static
    * @param {string} CategoryName Category name to be created
    * @returns {object} A created category object
-   * @memberof UserHelper
+   * @memberof CategoryHelper
    */
   static async createCategory(categoryName) {
     try {
@@ -24,6 +24,34 @@ class CategoryHelper {
         errorHandler(400, 'A category with that name exists.');
       }
       const createdCategory = await pool.query(query.createCategory(categoryName));
+      return createdCategory.rows[0];
+    } catch (error) {
+      return error;
+    }
+  }
+
+  /**
+   *
+   * @description Helper method that updates a new product category
+   * @static
+   * @param {object} CategoryInfo Category information to be updated
+   * @returns {object} An updated category
+   * @memberof CategoryHelper
+   */
+  static async updateCategory(categoryInfo) {
+    try {
+      const foundCategory = await pool.query(query.findCategoryById(categoryInfo.id));
+      if (foundCategory.rows.length < 1) {
+        errorHandler(404, 'The category not found.');
+      }
+      const allCategories = await pool.query(query.getAllCategories());
+      const isCategoryExists = allCategories.rows.some(
+        category => category.categoryname === categoryInfo.name
+      );
+      if (isCategoryExists) {
+        errorHandler(400, 'The category name already exists.');
+      }
+      const createdCategory = await pool.query(query.updateCategory(categoryInfo.id, categoryInfo.name));
       return createdCategory.rows[0];
     } catch (error) {
       return error;

--- a/server/middleware/inputValidator.js
+++ b/server/middleware/inputValidator.js
@@ -47,7 +47,15 @@ const validateNewCategory = [
   }),
   body('name')
     .isLength({ min: 2 })
-    .withMessage('Caregory name must be atleast 2 letters long')
+    .withMessage('Category name must be atleast 2 letters long')
+];
+
+const validateUpdateCategory = [
+  param('id')
+    .isInt({ min: 1 })
+    .withMessage('Category ID must be a positve integer from 1'),
+  validateNewCategory[0],
+  validateNewCategory[1]
 ];
 
 const validateProductId = [
@@ -135,6 +143,7 @@ const validations = {
   validateUserUpdate,
   validateUserDelete,
   validateNewCategory,
+  validateUpdateCategory,
   validateSaleId,
   validateNewSale,
   validateProductUpdate,

--- a/server/routes/category/category.js
+++ b/server/routes/category/category.js
@@ -14,4 +14,13 @@ router.post(
   CategoryController.createCategory
 );
 
+router.put(
+  '/:id',
+  authMiddleware.verifyToken,
+  authMiddleware.adminOnly,
+  validtor.validateUpdateCategory,
+  validtor.validationHandler,
+  CategoryController.updateCategory
+);
+
 export default router;

--- a/server/tests/01-controllers/02-categoryController.spec.js
+++ b/server/tests/01-controllers/02-categoryController.spec.js
@@ -113,4 +113,64 @@ describe('Category', () => {
       userHelperStub.restore();
     });
   });
+
+  describe('Modify Category', () => {
+    it('Should return an authentication error when authorization headers are not present', async () => {
+      const response = await chai.request(app).put('/api/v1/category/1');
+
+      expect(response.status).to.equal(401);
+      expect(response.body).to.have.property('message');
+      expect(response.body).to.have.property('status');
+      expect(response.body.status).to.be.a('boolean');
+      expect(response.body.status).to.equal(false);
+    });
+
+    it('Should return an authentication error when an invalid token is passed', async () => {
+      const response = await chai
+        .request(app)
+        .put('/api/v1/category/1')
+        .set('Authorization', `Bearer WrongToken`)
+        .send(mockData.category.validUpdateName);
+
+      expect(response.status).to.equal(401);
+      expect(response.body).to.have.property('message');
+      expect(response.body).to.have.property('status');
+      expect(response.body.status).to.be.a('boolean');
+      expect(response.body.status).to.equal(false);
+    });
+
+    it('Admin should not be able to update a category with non-existing id', async () => {
+      const response = await chai
+        .request(app)
+        .put('/api/v1/category/10')
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .send(mockData.category.validUpdateName);
+
+      expect(response.status).to.equal(404);
+      expect(response.body.message).to.equal('The category not found.');
+    });
+
+    it('Admin should not be able to update a category with an existing category name', async () => {
+      const response = await chai
+        .request(app)
+        .put('/api/v1/category/1')
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .send(mockData.category.existingCategoryName);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.message).to.equal('The category name already exists.');
+    });
+
+    it('Admin should be able to update a category', async () => {
+      const response = await chai
+        .request(app)
+        .put('/api/v1/category/1')
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .send(mockData.category.validUpdateName);
+
+      expect(response.status).to.equal(200);
+      expect(response.body).to.have.property('result');
+      expect(response.body.result).to.have.keys(['categoryid', 'categoryname']);
+    });
+  });
 });

--- a/server/tests/mock/index.js
+++ b/server/tests/mock/index.js
@@ -71,8 +71,14 @@ const category = {
   validCategoryName: {
     name: 'Electronics'
   },
+  existingCategoryName: {
+    name: 'Electronics'
+  },
   invalidCategoryName: {
     name: 'E'
+  },
+  validUpdateName: {
+    name: 'Mobile Phones'
   }
 };
 

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -22,9 +22,18 @@ const query = {
     text: `SELECT * FROM category WHERE categoryname = $1`,
     values: [name]
   }),
+  findCategoryById: id => ({
+    text: `SELECT * FROM category WHERE categoryid = $1`,
+    values: [id]
+  }),
+  getAllCategories: () => `SELECT * FROM category`,
   createCategory: name => ({
     text: `INSERT INTO category (categoryname) VALUES ($1) RETURNING *`,
     values: [name]
+  }),
+  updateCategory: (id, name) => ({
+    text: `UPDATE category SET categoryname = $1 WHERE categoryid = $2 RETURNING *`,
+    values: [name, id]
   })
 };
 


### PR DESCRIPTION
#### What does this PR do?
* Implement a modify product category feature that enables a store admins only to be able to update a product category

#### Description of Task to be completed?
- Write tests
- Setup routing scripts for the feature
- Secure route with jwt to allow access for store admins only
- Validate route parameters with the validation module
- Implement controller and helper class for the functionality

#### How should this be manually tested?
- Clone the repo `git clone https://github.com/jesseinit/store-manager.git`
- Checkout to the branch `git checkout ft-modify-category-161531945`
- Install Postgresql from [here](https://www.postgresql.org/download/)
- Create a database named `storemanager`
- Run `npm install` to install application dependencies
- Run `npm run migration` to seed database with required data
- Test by `npm test`

#### What are the relevant pivotal tracker stories?
[#161531945](https://www.pivotaltracker.com/story/show/161531945)