### PR TITLE
#161531958 Implement a feature that retrieve products categories

### DIFF
--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -47,6 +47,25 @@ class CategoryController {
     }
     res.status(200).json({ status: true, result });
   }
+
+  /**
+   *
+   * @description Retrieves all product categories in the store
+   * @static
+   * @param {object} req Request Object
+   * @param {object} res Response Object
+   * @param {object} next calls the next middleware in the request-response cycle
+   * @returns {array} List of all product categories
+   * @memberof CategoryController
+   */
+  static async getAllCategories(req, res, next) {
+    const result = await CategoryHelper.getAllCategories();
+    if (result instanceof Error) {
+      next(result);
+      return;
+    }
+    res.status(200).json({ status: true, result });
+  }
 }
 
 export default CategoryController;

--- a/server/helpers/categoryHelper.js
+++ b/server/helpers/categoryHelper.js
@@ -57,6 +57,25 @@ class CategoryHelper {
       return error;
     }
   }
+
+  /**
+   *
+   * @description Helper method that retrieves all product categories
+   * @static
+   * @returns {array} A list of product categories
+   * @memberof CategoryHelper
+   */
+  static async getAllCategories() {
+    try {
+      const allCategories = await pool.query(query.getAllCategories());
+      if (allCategories.rows.length < 1) {
+        return 'You have no product category yet.';
+      }
+      return allCategories.rows;
+    } catch (error) {
+      return error;
+    }
+  }
 }
 
 export default CategoryHelper;

--- a/server/middleware/inputValidator.js
+++ b/server/middleware/inputValidator.js
@@ -40,11 +40,17 @@ const validateUserUpdate = [
 const validateUserDelete = [validateUserUpdate[0]];
 
 const validateNewCategory = [
-  sanitizeBody('name').customSanitizer(value => {
-    let sanitizedValue = value.replace(/\s\s+/g, ' ').trim();
-    sanitizedValue = sanitizedValue[0].toUpperCase() + sanitizedValue.slice(1);
-    return sanitizedValue;
-  }),
+  sanitizeBody('name').customSanitizer(value =>
+    value
+      .toLowerCase()
+      .split(' ')
+      .map(s => s[0].toUpperCase() + s.substring(1))
+      .join(' ')
+      .replace(/([\W_\d])+([\s])/g, '')
+      .replace(/[0-9]/g, '')
+      .replace(/\s\s+/g, ' ')
+      .trim()
+  ),
   body('name')
     .isLength({ min: 2 })
     .withMessage('Category name must be atleast 2 letters long')

--- a/server/routes/category/category.js
+++ b/server/routes/category/category.js
@@ -23,4 +23,11 @@ router.put(
   CategoryController.updateCategory
 );
 
+router.get(
+  '/',
+  authMiddleware.verifyToken,
+  authMiddleware.adminOnly,
+  CategoryController.getAllCategories
+);
+
 export default router;

--- a/server/tests/01-controllers/02-categoryController.spec.js
+++ b/server/tests/01-controllers/02-categoryController.spec.js
@@ -172,5 +172,79 @@ describe('Category', () => {
       expect(response.body).to.have.property('result');
       expect(response.body.result).to.have.keys(['categoryid', 'categoryname']);
     });
+
+    it('It should handle error from database failure when updating a category', async () => {
+      const userHelperStub = sinon.stub(CategoryHelper, 'updateCategory').returns(new Error());
+      const resonse = await chai
+        .request(app)
+        .put('/api/v1/category/1')
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .send(mockData.category.validCategoryName);
+
+      expect(resonse.status).to.equal(500);
+      userHelperStub.restore();
+    });
+  });
+
+  describe('Get All Categories', () => {
+    it('Should return an authentication error when authorization headers are not present', async () => {
+      const response = await chai.request(app).get('/api/v1/category/');
+
+      expect(response.status).to.equal(401);
+      expect(response.body).to.have.property('message');
+      expect(response.body).to.have.property('status');
+      expect(response.body.status).to.be.a('boolean');
+      expect(response.body.status).to.equal(false);
+    });
+
+    it('Should return an authentication error when an invalid token is passed', async () => {
+      const response = await chai
+        .request(app)
+        .get('/api/v1/category/')
+        .set('Authorization', `Bearer WrongToken`);
+
+      expect(response.status).to.equal(401);
+      expect(response.body).to.have.property('message');
+      expect(response.body).to.have.property('status');
+      expect(response.body.status).to.be.a('boolean');
+      expect(response.body.status).to.equal(false);
+    });
+
+    it('Admin should be get a message when there are no created categories', async () => {
+      const userHelperStub = sinon
+        .stub(CategoryHelper, 'getAllCategories')
+        .returns('You have no product category yet.');
+
+      const response = await chai
+        .request(app)
+        .get('/api/v1/category/')
+        .set('Authorization', `Bearer ${ownerToken}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body).to.have.property('result');
+      userHelperStub.restore();
+    });
+
+    it('Admin should be able to see all categories', async () => {
+      const response = await chai
+        .request(app)
+        .get('/api/v1/category/')
+        .set('Authorization', `Bearer ${ownerToken}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body).to.have.property('result');
+    });
+
+    it('It should handle error from database failure when getting all categories', async () => {
+      const userHelperStub = sinon.stub(CategoryHelper, 'getAllCategories').returns(new Error());
+      const resonse = await chai
+        .request(app)
+        .get('/api/v1/category/')
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .send(mockData.category.validCategoryName);
+
+      expect(resonse.status).to.equal(500);
+      userHelperStub.restore();
+    });
   });
 });

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -26,7 +26,7 @@ const query = {
     text: `SELECT * FROM category WHERE categoryid = $1`,
     values: [id]
   }),
-  getAllCategories: () => `SELECT * FROM category`,
+  getAllCategories: () => `SELECT DISTINCT categoryid, categoryname from category`,
   createCategory: name => ({
     text: `INSERT INTO category (categoryname) VALUES ($1) RETURNING *`,
     values: [name]


### PR DESCRIPTION
#### What does this PR do?
* Implement a feature that enables a store admins only to be able to retrieve products categories

#### Description of Task to be completed?
- Write tests
- Setup routing scripts for the feature
- Secure route with jwt to allow access for store admins only
- Implement controller and helper class for the functionality

#### How should this be manually tested?
- Clone the repo `git clone https://github.com/jesseinit/store-manager.git`
- Checkout to the branch `git checkout ft-get-all-category-161531958`
- Install Postgresql from [here](https://www.postgresql.org/download/)
- Create a database named `storemanager`
- Run `npm install` to install application dependencies
- Run `npm run migration` to seed database with required data
- Test by `npm test`

#### What are the relevant pivotal tracker stories?
[#161531958](https://www.pivotaltracker.com/story/show/161531958)