### PR TITLE
#161531948 Implement a feature that deletes a product's category

### DIFF
--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -66,6 +66,26 @@ class CategoryController {
     }
     res.status(200).json({ status: true, result });
   }
+
+  /**
+   *
+   * @description Deletes a product categories in the store
+   * @static
+   * @param {object} req Request Object
+   * @param {object} res Response Object
+   * @param {object} next calls the next middleware in the request-response cycle
+   * @returns {boolean} Result of the operation
+   * @memberof CategoryController
+   */
+  static async deleteCategory(req, res, next) {
+    const { id } = req.params;
+    const result = await CategoryHelper.deleteCategory(id);
+    if (result instanceof Error) {
+      next(result);
+      return;
+    }
+    res.status(200).json({ status: true, result });
+  }
 }
 
 export default CategoryController;

--- a/server/helpers/categoryHelper.js
+++ b/server/helpers/categoryHelper.js
@@ -76,6 +76,27 @@ class CategoryHelper {
       return error;
     }
   }
+
+  /**
+   *
+   * @description Deletes a product category
+   * @static
+   * @param {number} categoryId Category Id to be deleted
+   * @returns {boolean} Result of the operation
+   * @memberof CategoryHelper
+   */
+  static async deleteCategory(categoryId) {
+    try {
+      const foundCategory = await pool.query(query.findCategoryById(categoryId));
+      if (foundCategory.rows.length < 1) {
+        errorHandler(404, 'Category not found');
+      }
+      await pool.query(query.deleteCategory(categoryId));
+      return true;
+    } catch (error) {
+      return error;
+    }
+  }
 }
 
 export default CategoryHelper;

--- a/server/middleware/inputValidator.js
+++ b/server/middleware/inputValidator.js
@@ -46,7 +46,6 @@ const validateNewCategory = [
       .split(' ')
       .map(s => s[0].toUpperCase() + s.substring(1))
       .join(' ')
-      .replace(/([\W_\d])+([\s])/g, '')
       .replace(/[0-9]/g, '')
       .replace(/\s\s+/g, ' ')
       .trim()
@@ -63,6 +62,8 @@ const validateUpdateCategory = [
   validateNewCategory[0],
   validateNewCategory[1]
 ];
+
+const validateCategoryId = [validateUpdateCategory[0]];
 
 const validateProductId = [
   param('id')
@@ -150,6 +151,7 @@ const validations = {
   validateUserDelete,
   validateNewCategory,
   validateUpdateCategory,
+  validateCategoryId,
   validateSaleId,
   validateNewSale,
   validateProductUpdate,

--- a/server/routes/category/category.js
+++ b/server/routes/category/category.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import validtor from '../../middleware/inputValidator';
+import validator from '../../middleware/inputValidator';
 import CategoryController from '../../controllers/categoryController';
 import authMiddleware from '../../middleware/auth';
 
@@ -9,8 +9,8 @@ router.post(
   '/',
   authMiddleware.verifyToken,
   authMiddleware.adminOnly,
-  validtor.validateNewCategory,
-  validtor.validationHandler,
+  validator.validateNewCategory,
+  validator.validationHandler,
   CategoryController.createCategory
 );
 
@@ -18,8 +18,8 @@ router.put(
   '/:id',
   authMiddleware.verifyToken,
   authMiddleware.adminOnly,
-  validtor.validateUpdateCategory,
-  validtor.validationHandler,
+  validator.validateUpdateCategory,
+  validator.validationHandler,
   CategoryController.updateCategory
 );
 
@@ -28,6 +28,15 @@ router.get(
   authMiddleware.verifyToken,
   authMiddleware.adminOnly,
   CategoryController.getAllCategories
+);
+
+router.delete(
+  '/:id',
+  authMiddleware.verifyToken,
+  authMiddleware.adminOnly,
+  validator.validateCategoryId,
+  validator.validationHandler,
+  CategoryController.deleteCategory
 );
 
 export default router;

--- a/server/tests/01-controllers/02-categoryController.spec.js
+++ b/server/tests/01-controllers/02-categoryController.spec.js
@@ -210,7 +210,7 @@ describe('Category', () => {
       expect(response.body.status).to.equal(false);
     });
 
-    it('Admin should be get a message when there are no created categories', async () => {
+    it('Admin should get a message when there are no created categories', async () => {
       const userHelperStub = sinon
         .stub(CategoryHelper, 'getAllCategories')
         .returns('You have no product category yet.');
@@ -245,6 +245,52 @@ describe('Category', () => {
 
       expect(resonse.status).to.equal(500);
       userHelperStub.restore();
+    });
+  });
+
+  describe('Delete Category', () => {
+    it('Should return an authentication error when authorization headers are not present', async () => {
+      const response = await chai.request(app).del('/api/v1/category/1');
+
+      expect(response.status).to.equal(401);
+      expect(response.body).to.have.property('message');
+      expect(response.body).to.have.property('status');
+      expect(response.body.status).to.be.a('boolean');
+      expect(response.body.status).to.equal(false);
+    });
+
+    it('Should return an authentication error when an invalid token is passed', async () => {
+      const response = await chai
+        .request(app)
+        .del('/api/v1/category/1')
+        .set('Authorization', `Bearer WrongToken`);
+
+      expect(response.status).to.equal(401);
+      expect(response.body).to.have.property('message');
+      expect(response.body).to.have.property('status');
+      expect(response.body.status).to.be.a('boolean');
+      expect(response.body.status).to.equal(false);
+    });
+
+    it('It should not be able to delete a non-existing category', async () => {
+      const response = await chai
+        .request(app)
+        .del('/api/v1/category/10')
+        .set('Authorization', `Bearer ${ownerToken}`);
+
+      expect(response.status).to.equal(404);
+      expect(response.body.message).to.equal('Category not found');
+    });
+
+    it('Admin should be able to delete a category', async () => {
+      const response = await chai
+        .request(app)
+        .del('/api/v1/category/1')
+        .set('Authorization', `Bearer ${ownerToken}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body).to.have.property('result');
+      expect(response.body.result).to.equal(true);
     });
   });
 });

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -34,6 +34,10 @@ const query = {
   updateCategory: (id, name) => ({
     text: `UPDATE category SET categoryname = $1 WHERE categoryid = $2 RETURNING *`,
     values: [name, id]
+  }),
+  deleteCategory: id => ({
+    text: `DELETE FROM category WHERE categoryid = $1`,
+    values: [id]
   })
 };
 


### PR DESCRIPTION
#### What does this PR do?
* Implement a feature that enables a store admins only to be able to delete a product category

#### Description of Task to be completed?
- Write tests
- Setup routing scripts for the feature
- Secure route with jwt to allow access for store admins only
- Implement controller and helper class for the functionality

#### How should this be manually tested?
- Clone the repo `git clone https://github.com/jesseinit/store-manager.git`
- Checkout to the branch `git checkout ft-delete-category-161531948`
- Install Postgresql from [here](https://www.postgresql.org/download/)
- Create a database named `storemanager`
- Run `npm install` to install application dependencies
- Run `npm run migration` to seed database with required data
- Test by `npm test`

#### What are the relevant pivotal tracker stories?
[#161531948](https://www.pivotaltracker.com/story/show/161531948)