### PR TITLE
#161922767 Consume delete category endpoint on the client

### DIFF
--- a/ui/css/app.css
+++ b/ui/css/app.css
@@ -86,6 +86,11 @@ a {
   padding: 20px;
 }
 
+.modal .form-body h3 {
+  font-size: 0.9rem;
+  margin-bottom: 10px;
+}
+
 .modal .form-body input,
 .modal .form-body select {
   display: block;
@@ -105,11 +110,13 @@ a {
 .modal .form-body button {
   padding: 10px;
   border: none;
+  border-radius: 5px;
   outline: none;
+  cursor: pointer;
 }
 
-.modal .form-body button#delete-user {
-  background: #ff1919;
+.modal .form-body button#confirm-delete {
+  background: #fa4e4e;
 }
 
 .table {

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -177,7 +177,7 @@ const userDeleteModal = async e => {
     `<div class="modal">
       <div class="form-body">
         <h3>Do you want to delete user?</h3>
-        <button data-id=${e.target.parentElement.getAttribute('data-id')} id='delete-user'>Yes</button>
+        <button data-id=${e.target.parentElement.getAttribute('data-id')} id='confirm-delete'>Yes</button>
         <button id='cancel'>No</button>
       </div>
     </div>`
@@ -186,7 +186,7 @@ const userDeleteModal = async e => {
   const modal = document.body.querySelector('.modal');
   modal.addEventListener('click', destroyModal);
 
-  const delUserBtn = document.querySelector('#delete-user');
+  const delUserBtn = document.querySelector('#confirm-delete');
   const cancelBtn = document.querySelector('#cancel');
 
   delUserBtn.addEventListener('click', deleteUser);
@@ -259,6 +259,45 @@ const updateCategory = async e => {
   document.body.removeChild(modal);
 };
 
+const deleteCategory = async e => {
+  const modal = document.body.querySelector('.modal');
+  const categoryId = Number(e.target.getAttribute('data-id'));
+  const deleteCategoryUrl = `${basepath}/category/${categoryId}`;
+  const deleteResponse = await processRequest(deleteCategoryUrl, 'DELETE');
+
+  if (!deleteResponse.status) {
+    toast(deleteResponse.message, errorToast);
+    document.body.removeChild(modal);
+    return;
+  }
+
+  toast('Category deleted successfully', successToast);
+  document.body.removeChild(modal);
+  populateCategoryTable();
+};
+
+const categoryDeleteModal = async e => {
+  document.body.insertAdjacentHTML(
+    'afterbegin',
+    `<div class="modal">
+      <div class="form-body">
+        <h3>Do you want to delete this category?</h3>
+        <button data-id=${e.target.parentElement.getAttribute('data-id')} id='confirm-delete'>Yes</button>
+        <button id='cancel'>No</button>
+      </div>
+    </div>`
+  );
+
+  const modal = document.body.querySelector('.modal');
+  modal.addEventListener('click', destroyModal);
+
+  const delUserBtn = document.querySelector('#confirm-delete');
+  const cancelBtn = document.querySelector('#cancel');
+
+  delUserBtn.addEventListener('click', deleteCategory);
+  cancelBtn.addEventListener('click', () => document.body.removeChild(modal));
+};
+
 const categoryEditModal = async e => {
   const singleCategoryUrl = `${basepath}/category/${e.target.parentElement.getAttribute('data-id')}`;
   const response = await processRequest(singleCategoryUrl);
@@ -293,7 +332,7 @@ const populateCategoryTable = async () => {
     const editBtn = categoryTableBody.querySelectorAll('button.blue');
     editBtn.forEach(btn => btn.addEventListener('click', categoryEditModal));
     const delBtn = categoryTableBody.querySelectorAll('button.red');
-    delBtn.forEach(btn => btn.addEventListener('click', userDeleteModal));
+    delBtn.forEach(btn => btn.addEventListener('click', categoryDeleteModal));
   });
 };
 


### PR DESCRIPTION
#### What does this PR do?
* Consume delete category endpoint on the client to enable category deletion.

#### Description of Task to be completed?
- Consume DELETE `api/v1/category/id` endpoint

#### How should this be manually tested?
- Clone the repo `git clone https://github.com/jesseinit/store-manager.git`
- Checkout to the branch `git checkout ft-consume-delete-category-161922767`
- Install Postgresql from [here](https://www.postgresql.org/download/)
- Create a database named `storemanager`
- Run `npm install` to install application dependencies
- Run `npm run migration` to seed database with required data
- Run `npm run dev` to start the development server
- Navigate to `http://localhost:3000/ui/`

#### What are the relevant pivotal tracker stories?
[#161922767](https://www.pivotaltracker.com/story/show/161922767)